### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-googlecampuspartyhackathon.de


### PR DESCRIPTION
googlecampuspartyhackathon.de is no more configured properly so this file breaks the github page (usually reachable via https://googlecampuspartyhackathon.github.io/welcome)

ps: why bother? i thought it's nice to have a page which reminds us of the hackathon... :)
